### PR TITLE
Added support for RGBIC model H6144

### DIFF
--- a/LightstripSyncClient/BluetoothLEConnectionManager.cs
+++ b/LightstripSyncClient/BluetoothLEConnectionManager.cs
@@ -251,7 +251,7 @@ namespace LightstripSyncClient
 
         public bool checkRGBIC()
         {
-            return lightStrip.Name.Contains("ihoment_H6143");
+            return lightStrip.Name.Contains("ihoment_H6143") || lightStrip.Name.Contains("ihoment_H6144");
         }
 
        


### PR DESCRIPTION
I have the RGBIC model H6144 and the app doesn't work for it. My suspicion is it requires a boolean check in the code I wrote, but I'm not sure how to test that so its actually not tested.