### PR TITLE
Bluetooth name starts with GBK_

### DIFF
--- a/LightstripSync.Library/BluetoothLEConnectionManager.cs
+++ b/LightstripSync.Library/BluetoothLEConnectionManager.cs
@@ -65,7 +65,7 @@ namespace LightstripSyncClient
             var bluetoothLEDevice = await BluetoothLEDevice.FromIdAsync(deviceInformation.Id);
 
             var deviceName = bluetoothLEDevice.Name;
-            return deviceName.Substring(0, 4) == "ihom" ? bluetoothLEDevice : null;
+            return (deviceName.Substring(0, 4) == "ihom" || deviceName.Substring(0, 4) == "GBK_") ? bluetoothLEDevice : null;
         }
 
         public async Task<bool> InitiateConnection(BluetoothLEDevice device)


### PR DESCRIPTION
The Bluetooth name of H61A0 starts with GBK_, so I thought I would try and add it.


Note: I don't know a lot of cs, if its wrong, please fix it.